### PR TITLE
Fix AppImage build with local runtime script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -307,3 +307,5 @@ cython_debug/
 
 # --- BUN ---
 bun.lock
+# AppImage runtime
+resources/runtime-*

--- a/forge.config.js
+++ b/forge.config.js
@@ -14,6 +14,11 @@ module.exports = {
             name: "@reforged/maker-appimage",
             config: {
                 name: "Timekeeper",
+                options: {
+                    // Use a local runtime so the build does not rely on
+                    // network access when creating the AppImage.
+                    runtime: "./resources/runtime-x86_64",
+                },
             },
         },
     ],

--- a/package.json
+++ b/package.json
@@ -15,7 +15,9 @@
     "start:ts:nocomp": "electron .",
     "start": "electron-forge start",
     "package": "electron-forge package",
-    "make": "electron-forge make"
+    "make": "electron-forge make",
+    "premake": "npm run build:all && npm run fetch:runtime",
+    "fetch:runtime": "bash scripts/fetch-runtime.sh"
   },
   "author": "Daniel Kolgushev",
   "license": "ISC",

--- a/scripts/fetch-runtime.sh
+++ b/scripts/fetch-runtime.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+FILE="resources/runtime-x86_64"
+if [ -f "$FILE" ]; then
+  echo "Runtime already downloaded: $FILE"
+  exit 0
+fi
+
+mkdir -p resources
+curl -L --fail https://github.com/AppImage/AppImageKit/releases/download/continuous/runtime-x86_64 -o "$FILE"
+chmod +x "$FILE"
+
+echo "Downloaded runtime to $FILE"


### PR DESCRIPTION
## Summary
- remove bundled runtime binary
- add fetch-runtime script
- call fetch-runtime in the premake npm script
- ignore runtime binaries

## Testing
- `npm test` *(fails: Missing script)*
- `npm run make`
- `./out/make/AppImage/x64/timekeeper-1.0.0-x64.AppImage --appimage-version`


------
https://chatgpt.com/codex/tasks/task_e_6871c55080d8832f9e57db73074c9ad2